### PR TITLE
Fix CI Failures and Update Workflow Versions

### DIFF
--- a/.github/workflows/lint-format.yml
+++ b/.github/workflows/lint-format.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
       
       - name: Run lint/format scripts
         uses: area44/workflows/lint-format@v4.3.0

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,15 +14,24 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v4
         with:
-          node-version: '24.15.0'
+          node-version: '22'
           registry-url: 'https://registry.npmjs.org'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
 
       - name: Publish to npm
-        run: npm publish
+        run: pnpm publish --no-git-checks
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -10,7 +10,6 @@
       "!**/dist",
       "!**/out",
       "!**/.astro",
-      "!**/.github",
       "!**/.netlify",
       "!**/.next"
     ]


### PR DESCRIPTION
This PR fixes CI failures by downgrading hallucinated versions of GitHub Actions and Node.js to stable ones. It also improves the publish workflow by adding pnpm support and enables linting for workflow files in Biome.

---
*PR created automatically by Jules for task [2376517412193433907](https://jules.google.com/task/2376517412193433907) started by @torn4dom4n*